### PR TITLE
Bugfix for compatibility with Ansible 2.1.0

### DIFF
--- a/templates/dumpall.j2
+++ b/templates/dumpall.j2
@@ -1,10 +1,6 @@
 {{ ansible_managed }}
 
 
-Module Variables ("vars"):
---------------------------------
-{{ vars | to_nice_json }}
-
 Environment Variables ("environment"):
 --------------------------------
 {{ environment | to_nice_json }}


### PR DESCRIPTION
The role does not work with Ansible 2.1.0

`TASK [f500.dumpall : Dump all vars] ********************************************
fatal: [192.168.60.13]: FAILED! => {"changed": false, "failed": true, "msg": "AnsibleError: Unexpected templating type error occurred on ({{ ansible_managed }}\n\n\nModule Variables (\"vars\"):\n--------------------------------\n{{ vars | to_nice_json }}\n\nEnvironment Variables (\"environment\"):\n--------------------------------\n{{ environment | to_nice_json }}\n\nGROUP NAMES Variables (\"group_names\"):\n--------------------------------\n{{ group_names | to_nice_json }}\n\nGROUPS Variables (\"groups\"):\n--------------------------------\n{{ groups | to_nice_json }}\n\nHOST Variables (\"hostvars\"):\n--------------------------------\n{{ hostvars[inventory_hostname] | to_nice_json }}\n): exceptions must be old-style classes or derived from BaseException, not type"}`

Open issue: https://github.com/f500/ansible-dumpall/issues/6
